### PR TITLE
Adb improvements

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3,16 +3,14 @@
 import sys
 import argparse
 import traceback
-import time
 import json
-from pathlib import Path
 import signal
 from src.core.logging import setup_logging, app_logger
-from src.core.device import cleanup_temp_files, cleanup_device_screenshots, ensure_dir
 from src.core.adb import get_connected_device
 from src.automation.automation import MainAutomation
 from src.core.cleanup import CleanupManager
 from src.automation.handler_factory import HandlerFactory
+
 
 def get_routine_config():
     try:

--- a/config/config.json
+++ b/config/config.json
@@ -254,7 +254,7 @@
     }
   },
   "adb": {
-    "ip": "",
+    "host": "",
     "port": -1,
     "binary_path": "adb",
     "enforce_connection": false

--- a/config/config.json
+++ b/config/config.json
@@ -252,5 +252,11 @@
       "embed_value": ":flag_us: A new dig has been posted! Get digging!\n:flag_kr: \uc0c8\ub85c\uc6b4 \ubc1c\uad74\uc774 \uac8c\uc2dc\ub418\uc5c8\uc2b5\ub2c8\ub2e4! \ubc1c\uad74\uc744 \uc2dc\uc791\ud558\uc138\uc694!",
       "embed_color": "0xFF0000"
     }
+  },
+  "adb": {
+    "ip": "",
+    "port": -1,
+    "binary_path": "adb",
+    "enforce_connection": false
   }
 }

--- a/src/core/adb.py
+++ b/src/core/adb.py
@@ -66,14 +66,15 @@ def get_device_list() -> List[str]:
             app_logger.debug(f"Unknown adb version found:\n{lines}")
 
         if CONFIG.adb["enforce_connection"]:
-            cmd = [CONFIG.adb["binary_path"], "connect", f"{CONFIG.adb['host']}:{CONFIG.adb['port']}"]
-            subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                check=True,
-                shell=True  # Required for Windows compatibility
-            )
+            if CONFIG.adb['host'] and CONFIG.adb['port'] and CONFIG.adb['port'] > 0:
+                cmd = [CONFIG.adb["binary_path"], "connect", f"{CONFIG.adb['host']}:{CONFIG.adb['port']}"]
+                subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                    shell=True  # Required for Windows compatibility
+                )
 
         cmd = [CONFIG.adb["binary_path"], "devices"]
         result = subprocess.run(

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -54,7 +54,7 @@ class ConfigManager:
     @property
     def adb(self) -> Dict[str, Any]:
         return self._config.get('adb', {
-            "ip": "",
+            "host": "",
             "port": -1,
             "binary_path": "adb",
             "enforce_connection": False

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -5,13 +5,14 @@ from typing import Dict, Any
 from pathlib import Path
 from src.core.logging import app_logger
 
+
 class ConfigManager:
     def __init__(self, config_dir: str = "config"):
         self.config_dir = Path(config_dir)
         self._config: Dict[str, Any] = {}
         self._automation_config: Dict[str, Any] = {}
         self._load_configs()
-        
+
     def _load_configs(self) -> None:
         """Load all configuration files"""
         try:
@@ -25,23 +26,23 @@ class ConfigManager:
                 self._config = {}
             if not self._automation_config:
                 self._automation_config = {}
-    
+
     def __getitem__(self, key: str) -> Any:
         """Allow dictionary-style access to main config"""
         return self._config.get(key, {})
-        
+
     def get(self, key: str, default: Any = None) -> Any:
         """Get value from main config with default"""
         return self._config.get(key, default)
-        
+
     @property
     def time_checks(self) -> Dict[str, Any]:
         return self._automation_config.get("time_checks", {})
-        
+
     @property
     def scheduled_events(self) -> Dict[str, Any]:
         return self._automation_config.get("scheduled_events", {})
-        
+
     @property
     def control_list(self) -> Dict[str, Any]:
         """Get control list from main config"""
@@ -49,6 +50,16 @@ class ConfigManager:
             "whitelist": {"alliance": []},
             "blacklist": {"alliance": []}
         })
+
+    @property
+    def adb(self) -> Dict[str, Any]:
+        return self._config.get('adb', {
+            "ip": "",
+            "port": -1,
+            "binary_path": "adb",
+            "enforce_connection": False
+        })
+
 
 # Create global instances
 CONFIG = ConfigManager()

--- a/src/core/device.py
+++ b/src/core/device.py
@@ -5,6 +5,7 @@ from typing import Optional, Tuple
 from .logging import app_logger
 from pathlib import Path
 import shutil
+from src.core.config import CONFIG
 
 def take_screenshot(device_id: str) -> bool:
     """Take screenshot and pull to local tmp directory"""
@@ -12,14 +13,14 @@ def take_screenshot(device_id: str) -> bool:
         ensure_dir("tmp")
         
         # Take screenshot on device
-        cmd = f"adb -s {device_id} shell screencap -p /sdcard/screen.png"
+        cmd = f"{CONFIG.adb["binary_path"]} -s {device_id} shell screencap -p /sdcard/screen.png"
         result = subprocess.run(cmd, capture_output=True, text=True)
         if result.returncode != 0:
             app_logger.error(f"Failed to take screenshot: {result.stderr}")
             return False
             
         # Pull screenshot to local tmp directory
-        cmd = f"adb -s {device_id} pull /sdcard/screen.png tmp/screen.png"
+        cmd = f"{CONFIG.adb["binary_path"]} -s {device_id} pull /sdcard/screen.png tmp/screen.png"
         result = subprocess.run(cmd, capture_output=True, text=True)
         if result.returncode != 0:
             app_logger.error(f"Failed to pull screenshot: {result.stderr}")
@@ -36,7 +37,7 @@ def take_screenshot(device_id: str) -> bool:
 def get_screen_size(device_id: str) -> Tuple[int, int]:
     """Get screen size from device"""
     try:
-        cmd = f"adb -s {device_id} shell wm size"
+        cmd = f"{CONFIG.adb["binary_path"]} -s {device_id} shell wm size"
         result = subprocess.run(cmd, capture_output=True, text=True)
         if result.returncode != 0:
             app_logger.error(f"Failed to get screen size: {result.stderr}")
@@ -53,7 +54,7 @@ def get_screen_size(device_id: str) -> Tuple[int, int]:
 def cleanup_device_screenshots(device_id: str) -> None:
     """Clean up screenshots from device"""
     try:
-        cmd = f"adb -s {device_id} shell rm -f /sdcard/screen*.png"
+        cmd = f"{CONFIG.adb["binary_path"]} -s {device_id} shell rm -f /sdcard/screen*.png"
         result = subprocess.run(cmd, capture_output=True, text=True)
         if result.returncode == 0:
             app_logger.debug("Cleaned up device screenshots")


### PR DESCRIPTION
With the current implementation, adb management does not offer much flexibility. The tool will generically try to run adb commands while searching for the main executable in known folders.

Once adb runs, the first one is used if multiple devices are found.

This pull request addresses these points by adding the following capabilities:

- The possibility to specify an adb executable path in the config file
- The possibility of specifying the expected host/port for the adb client
- The option to enforce the connection to a specific device

All of the above besides giving more flexibility, also open for the possibility of running multiple bots on the same machine.