### PR TITLE
Improve take_screenshot() logic.

### DIFF
--- a/src/core/device.py
+++ b/src/core/device.py
@@ -1,7 +1,7 @@
 """Device interaction utilities"""
 
 import subprocess
-from typing import Optional, Tuple
+from typing import Tuple
 from .logging import app_logger
 from pathlib import Path
 import shutil
@@ -11,22 +11,23 @@ def take_screenshot(device_id: str) -> bool:
     """Take screenshot and pull to local tmp directory"""
     try:
         ensure_dir("tmp")
-        
-        # Take screenshot on device
-        cmd = f"{CONFIG.adb['binary_path']} -s {device_id} shell screencap -p /sdcard/screen.png"
-        result = subprocess.run(cmd, capture_output=True, text=True)
-        if result.returncode != 0:
-            app_logger.error(f"Failed to take screenshot: {result.stderr}")
-            return False
-            
-        # Pull screenshot to local tmp directory
-        cmd = f"{CONFIG.adb['binary_path']} -s {device_id} pull /sdcard/screen.png tmp/screen.png"
-        result = subprocess.run(cmd, capture_output=True, text=True)
-        if result.returncode != 0:
-            app_logger.error(f"Failed to pull screenshot: {result.stderr}")
-            return False
-            
-        # Clean up device screenshots
+
+        # pipe = subprocess.Popen(f"{CONFIG.adb["binary_path"]} exec-out screencap -p",
+        #                         stdin=subprocess.PIPE,
+        #                         stdout=subprocess.PIPE, shell=True)
+        # image_bytes = pipe.stdout.read()  # .replace(b'\r\n', b'\n')
+        # image = cv2.imdecode(np.fromstring(image_bytes, np.uint8), cv2.IMREAD_COLOR)
+        #
+        # cv2.imwrite("tmp/screen.png", image)
+
+        cmd = [CONFIG.adb["binary_path"], "exec-out", "screencap", "-p"]
+        with open('tmp/screen.png', "w") as outfile:
+            result = subprocess.run(cmd, stdout=outfile)
+            if result.returncode != 0:
+                app_logger.error(f"Failed to pull screenshot: {result.stderr}")
+                return False
+
+        # Clean up device screenshot
         cleanup_device_screenshots(device_id)
         return True
         


### PR DESCRIPTION
While profiling the code, I noticed that the take_screenshot() is really slow in terms of performance. Analyzing the code this is probably due to the fact that the screenshot is:

- Taken the first time and saved on the SD card of the device
- Subsequently copied to the local /tmp directory

This pull request aims at optimizing this by doing the following:
- The screenshot is taken with the exec-out adb command
- The output is piped directly to the local /tmp directory

Please note: there is the possibility to improve the logic even further piping the screenshot directly to a cv2 image. This would require a more complicated review of the code so the logic to do so is included in comments.